### PR TITLE
feat: add CI/CD workflow for queue-service

### DIFF
--- a/.github/workflows/queue-service-ci.yml
+++ b/.github/workflows/queue-service-ci.yml
@@ -21,6 +21,7 @@ permissions:
 
 jobs:
   build-and-test:
+    name: Build and Test queue-service
     runs-on: ubuntu-latest
 
     steps:
@@ -34,13 +35,13 @@ jobs:
           java-version: 17
           cache: gradle
 
-      - name: Grant execute permission
-        run: chmod +x gradlew
+      - name: Grant execute permission for Gradle wrapper
+        run: chmod +x ./gradlew
 
       - name: Run tests
         env:
-          GPR_USER: ${{ github.actor }}
-          GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPR_USER: ${{ secrets.GPR_USER }}
+          GPR_TOKEN: ${{ secrets.GPR_TOKEN }}
           QUEUE_TOKEN_SECRET: ${{ secrets.QUEUE_TOKEN_SECRET }}
         run: ./gradlew clean test
 

--- a/.github/workflows/queue-service-deploy.yml
+++ b/.github/workflows/queue-service-deploy.yml
@@ -1,0 +1,72 @@
+name: Queue Service CD
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: 3s-ticketing/queue-service
+  IMAGE_TAG: main-latest
+
+jobs:
+  build-and-push:
+    name: Build and Push queue-service image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Grant execute permission for Gradle wrapper
+        run: chmod +x ./gradlew
+
+      - name: Run tests
+        env:
+          GPR_USER: ${{ secrets.GPR_USER }}
+          GPR_TOKEN: ${{ secrets.GPR_TOKEN }}
+          QUEUE_TOKEN_SECRET: ${{ secrets.QUEUE_TOKEN_SECRET }}
+        run: ./gradlew clean test
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GPR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GPR_USER }} --password-stdin
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            --build-arg GPR_USER=${{ secrets.GPR_USER }} \
+            --build-arg GPR_TOKEN=${{ secrets.GPR_TOKEN }} \
+            -t $REGISTRY/$IMAGE_NAME:$IMAGE_TAG \
+            -t $REGISTRY/$IMAGE_NAME:${{ github.sha }} \
+            .
+
+      - name: Push Docker image
+        run: |
+          docker push $REGISTRY/$IMAGE_NAME:$IMAGE_TAG
+          docker push $REGISTRY/$IMAGE_NAME:${{ github.sha }}
+
+      - name: Deploy queue-service to EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            echo "${{ secrets.GPR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GPR_USER }} --password-stdin
+            cd ~/deploy/ticketing/ticketing-system
+            docker compose -f docker-compose.app.yml pull queue-service
+            docker compose -f docker-compose.app.yml up -d --no-deps --force-recreate queue-service
+            docker ps --filter "name=ticketing-queue-service"
+            docker image prune -f

--- a/.github/workflows/queue-service-deploy.yml
+++ b/.github/workflows/queue-service-deploy.yml
@@ -41,7 +41,7 @@ jobs:
         run: ./gradlew clean test
 
       - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.GPR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GPR_USER }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build Docker image
         run: |


### PR DESCRIPTION
### 📎 관련 이슈
- close #16 

### 📌 작업 내용
- queue-service에 GitHub Actions 기반 CI/CD workflow를 도입했습니다.
- PR/push 시 Gradle test를 수행하는 CI workflow를 정리했습니다.
- main 브랜치 병합 시 Docker 이미지를 build/push하고, GHCR에 `main-latest` 태그로 배포하도록 CD workflow를 추가했습니다.
- GHCR 이미지 push 이후 EC2에 SSH로 접속하여 queue-service 컨테이너만 자동 재배포하도록 구성했습니다.

### ✨ 변경 사항
- `.github/workflows/queue-service-ci.yml` 수정
- `.github/workflows/queue-service-deploy.yml` 추가
- GHCR 이미지 build/push 설정 추가
  - `ghcr.io/3s-ticketing/queue-service:main-latest`
  - `ghcr.io/3s-ticketing/queue-service:{commit-sha}`
- EC2 배포 단계 추가
  - `docker compose -f docker-compose.app.yml pull queue-service`
  - `docker compose -f docker-compose.app.yml up -d --no-deps --force-recreate queue-service`
- 배포 시 EC2 내부에서 GHCR 인증을 수행하도록 `docker login ghcr.io` 단계 추가
- 배포 후 `ticketing-queue-service` 컨테이너 상태 확인 명령 추가
- 테스트 실패 시 로그 출력 및 테스트 리포트 artifact 업로드 설정 유지

### 📝 리뷰 포인트 (선택)
- workflow 내 서비스명, 이미지명, 컨테이너명이 queue-service 기준으로 올바르게 설정되었는지 확인 부탁드립니다.
  - image: `ghcr.io/3s-ticketing/queue-service:main-latest`
  - compose service: `queue-service`
  - container: `ticketing-queue-service`
- 전체 서비스를 재기동하지 않고 queue-service만 재배포하도록 `--no-deps --force-recreate queue-service` 옵션을 사용했습니다.
- GitHub Secrets 설정이 정상 적용되는지 확인이 필요합니다.
  - `GPR_USER`
  - `GPR_TOKEN`
  - `EC2_HOST`
  - `EC2_USER`
  - `EC2_SSH_KEY`
  - `QUEUE_TOKEN_SECRET`

### 🧠 기타 참고 사항
- user-service에서 동일한 방식의 CI/CD 자동 배포 흐름을 먼저 검증했습니다.
- club-service, match-service, payment-service에도 동일한 방식의 CI/CD workflow를 적용 중입니다.
- `ticketing-system/docker-compose.app.yml`에서 queue-service가 `image: ghcr.io/3s-ticketing/queue-service:main-latest`를 바라보도록 변경되어 있어야 `docker compose pull queue-service`가 정상 동작합니다.
- main 병합 후 Actions 탭에서 CD workflow 성공 여부와 EC2 컨테이너 재기동 여부를 확인할 예정입니다.